### PR TITLE
React Band Client error checking and able to connect to C# Band Server

### DIFF
--- a/BandTree.Server/Program.cs
+++ b/BandTree.Server/Program.cs
@@ -8,6 +8,15 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHttpClient(); // Add HttpClient support - talking to Wikipedia API
 
+// Deals with CORS - Cross Origin Resource Sharing
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowSpecificOrigin",
+        builder => builder.WithOrigins("http://localhost:3000") // Specify the exact origin of your React app
+                          .AllowAnyHeader()
+                          .AllowAnyMethod());
+});
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
@@ -41,6 +50,10 @@ app.UseHttpsRedirection();
  * 
  */
 app.UseAuthorization();
+
+// Configure the HTTP request pipeline.
+// Deals with CORS - Cross Origin Resource Sharing
+app.UseCors("AllowSpecificOrigin"); // Use the policy
 
 // https://localhost:7100/
 // returns Hello World!

--- a/bandtree-client-gui/package-lock.json
+++ b/bandtree-client-gui/package-lock.json
@@ -13,8 +13,12 @@
         "@testing-library/user-event": "^13.5.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "http-proxy-middleware": "^2.0.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -643,9 +647,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1882,6 +1894,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -3669,104 +3692,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/gregberge"
-      }
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-      "integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-      "peer": true,
-      "dependencies": {
-        "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "peer": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "peer": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -16960,19 +16885,6 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/bandtree-client-gui/package.json
+++ b/bandtree-client-gui/package.json
@@ -8,7 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -34,5 +34,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+    "http-proxy-middleware": "^2.0.6"
   }
 }

--- a/bandtree-client-gui/setupProxy.js
+++ b/bandtree-client-gui/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/wikipedia-search',
+    createProxyMiddleware({
+      target: 'https://localhost:7088', // Your server's URL
+      changeOrigin: true,
+    })
+  );
+};

--- a/bandtree-client-gui/src/App.js
+++ b/bandtree-client-gui/src/App.js
@@ -18,7 +18,7 @@ function App() {
         >
           Learn React John again here it is 1/02/2024 14:52
         </a>
-        John Text 15:16 <WikipediaSearch />
+        John Text @ 15:16 <WikipediaSearch />
       </header>
     </div>
   );

--- a/bandtree-client-gui/src/BandTree_Client_WikipediaSearch.js
+++ b/bandtree-client-gui/src/BandTree_Client_WikipediaSearch.js
@@ -15,7 +15,7 @@ function WikipediaSearch() {
 
     //              https://localhost:7088/wikipedia-search?searchTerm=aldo%20nova
     const encodedSearchTerm = encodeURIComponent(searchTerm);
-    const apiUrl = `/wikipedia-search?searchTerm=${encodedSearchTerm}`;
+    const apiUrl = `https://localhost:7088/wikipedia-search?searchTerm=${encodedSearchTerm}`;
 
     // Display the apiUrl before sending the request
     setDisplayedApiUrl(apiUrl);
@@ -34,7 +34,7 @@ function WikipediaSearch() {
     })
       .then((response) => {
         if (!response.ok) {
-          throw new Error(`Band Client calling Band Server HTTP error! Used URL ${apiUrl} Status: ${response.status}`);
+          throw new Error(`Band Client HTTP error calling Band Server! Used URL ${apiUrl} Status: ${response.status}`);
         }
         return response.json();
       })
@@ -46,8 +46,10 @@ function WikipediaSearch() {
         setError(null); // Clear any previous errors
       })
       .catch((error) => {
-        console.error('Unknown Band Client to Band Server Error: ', error);
+        console.error('.catch Unknown Band Client to Band Server Error: ', error);
         // Set the error state to display a message to the user
+        // If the error is "TypeError: NetworkError when attempting to fetch resource."
+        // then the Band Server is not running is one possible reason.
         setError(
           <>
             Band Client: .catch error occurred while trying to fetch information from the Band Server.
@@ -57,7 +59,7 @@ function WikipediaSearch() {
             and apiUrl: {apiUrl}
             <br />
             <br />
-            {error.toString()}
+            ( {error.toString()} )
             <br />
           </>
         );
@@ -70,6 +72,7 @@ function WikipediaSearch() {
   return (
     <div>
       <h1>Musician Family Tree Search via ! Wikipedia !</h1>
+      <h2>version 1/02/2024 18:44</h2>
       <div>
         <input
           type="text"
@@ -82,7 +85,9 @@ function WikipediaSearch() {
       <div>
         {displayedApiUrl && (
             <p>
-              Band Client Request URL: <code>{displayedApiUrl}</code>
+              Band Client URL Request sent to Band Server:
+              <br />
+               <code>{displayedApiUrl}</code>
             </p>
           )}
           {isLoading ? (
@@ -91,10 +96,10 @@ function WikipediaSearch() {
             <p>{error}</p>
           ) : (
             <>
-              <h2>Results</h2>
+              <h2>Raw JSON Results via Band Server from Wikipedia</h2>
               <textarea
-                rows="10"
-                cols="50"
+                rows="25"
+                cols="150"
                 value={results}
                 readOnly
               />

--- a/bandtree-client-gui/src/BandTree_Client_WikipediaSearch.js
+++ b/bandtree-client-gui/src/BandTree_Client_WikipediaSearch.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 
 function WikipediaSearch() {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [results, setResults] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [searchTerm, setSearchTerm]           = useState('');
+  const [results, setResults]                 = useState('');
+  const [isLoading, setIsLoading]             = useState(false);
+  const [error, setError]                     = useState(null);
+  const [displayedApiUrl, setDisplayedApiUrl] = useState('');
 
   const handleSearch = () => {
     if (!searchTerm) {
@@ -12,17 +13,28 @@ function WikipediaSearch() {
       return;
     }
 
-    //              https://localhost:7088
-    const apiUrl = `https://localhost:7088/wikipedia-search?search=${searchTerm}`;
+    //              https://localhost:7088/wikipedia-search?searchTerm=aldo%20nova
+    const encodedSearchTerm = encodeURIComponent(searchTerm);
+    const apiUrl = `/wikipedia-search?searchTerm=${encodedSearchTerm}`;
 
+    // Display the apiUrl before sending the request
+    setDisplayedApiUrl(apiUrl);
     
     // Indicate that a request is in progress
     setIsLoading(true);
 
-    fetch(apiUrl)
+    fetch(apiUrl, {
+      method: 'PUT', // Specify the HTTP method as PUT
+      headers: {
+        'Content-Type': 'application/json', // Set the content type if you are sending JSON data
+        // Add any other headers as needed
+      }
+      // ,
+      // body: JSON.stringify(sendBodyData), // Include the request payload if necessary
+    })
       .then((response) => {
         if (!response.ok) {
-          throw new Error(`Band Client calling Band Server HTTP error! Status: ${response.status}`);
+          throw new Error(`Band Client calling Band Server HTTP error! Used URL ${apiUrl} Status: ${response.status}`);
         }
         return response.json();
       })
@@ -38,9 +50,15 @@ function WikipediaSearch() {
         // Set the error state to display a message to the user
         setError(
           <>
-            Band Client: An error occurred while fetching data from Band Server.
+            Band Client: .catch error occurred while trying to fetch information from the Band Server.
+            <br />
+            with search term: {searchTerm}
+            <br />
+            and apiUrl: {apiUrl}
+            <br />
             <br />
             {error.toString()}
+            <br />
           </>
         );
         
@@ -51,7 +69,7 @@ function WikipediaSearch() {
 
   return (
     <div>
-      <h1>Wikipedia Search</h1>
+      <h1>Musician Family Tree Search via ! Wikipedia !</h1>
       <div>
         <input
           type="text"
@@ -62,21 +80,26 @@ function WikipediaSearch() {
         <button onClick={handleSearch}>Search if Artist or Band exists in English WikiPedia</button>
       </div>
       <div>
-      {isLoading ? (
-          <p>Loading...</p>
-        ) : error ? (
-          <p>{error}</p>
-        ) : (
-          <>
-            <h2>Results</h2>
-            <textarea
-              rows="10"
-              cols="50"
-              value={results}
-              readOnly
-            />
-          </>
-        )}
+        {displayedApiUrl && (
+            <p>
+              Band Client Request URL: <code>{displayedApiUrl}</code>
+            </p>
+          )}
+          {isLoading ? (
+            <p>Loading...</p>
+          ) : error ? (
+            <p>{error}</p>
+          ) : (
+            <>
+              <h2>Results</h2>
+              <textarea
+                rows="10"
+                cols="50"
+                value={results}
+                readOnly
+              />
+            </>
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds more error checking to see any errors from Server if a problem on the Client side.
Added line in GUI to show URL send to Band Server.

C# Band Server had to allow CORS - Cross Origin Resource Sharing to have the React App GUI and this Band Server both use LocalHost:port options.

PostMan was able to make a call to the Band Server with locahost:portA but the React GUI had it's own locahost:portB

Fixed the Cross-Origin Resource Sharing (CORS) for the React App using localhost:port calling the Band Server who was also a locahost:port

Had to add setupProxy.js and view the Band Server commit to see it's CORS setting fix.  Need to look up how to change that for production compile.
Also figured out with Chat and StackOverflow how to deal with babel dependency deprecation warning on App startup via packate.json addition of https://github.com/babel to devDependencies